### PR TITLE
Feat: Add webhook message when deploy is complete

### DIFF
--- a/.github/workflows/deploy_to_minebot_server.yml
+++ b/.github/workflows/deploy_to_minebot_server.yml
@@ -92,7 +92,19 @@ jobs:
             docker compose pull
             docker compose down
             docker compose up -d
-            
-            
-            
+
+  webhook:
+    needs: 
+      - deploy
+    runs-on: ubuntu-latest
+    steps:
+        - name: Discord Webhook Action
+          uses: tsickert/discord-webhook@v5.3.0
+          with:
+            webhook-url: ${{ secrets.MINEBOT__WEBHOOK__URL }}
+            embed-title: "Minebot"
+            embed-color: 4771125
+            embed-description: "Uma nova versão do bot foi deployada e já está disponível para uso!"
+            username: "Minebot"
+          
             

--- a/src/commands/status/embeds/status/success.rs
+++ b/src/commands/status/embeds/status/success.rs
@@ -12,7 +12,8 @@ pub fn create_success_embed(
             .iter()
             .map(|player| player.name.clone())
             .collect::<Vec<String>>()
-            .join("\n"),
+            .join("\n")
+            .replace("_", "\\_"),
         None => String::from("No players online"),
     };
 


### PR DESCRIPTION
A new action was created to send a message to discord as soon as the deployment is completed via Webhooks.
In order for no errors to occur, it is necessary to use a secret in the repo called `MINEBOT__WEBHOOK__URL` which will tell the URL of the webhook where the message will be sent.